### PR TITLE
Properly conform to gem naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the urbit console you have been waiting for
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'mars-base-10'
+gem 'mars_base_10'
 ```
 
 And then execute:
@@ -16,7 +16,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install mars-base-10
+    $ gem install mars_base_10
 
 ## Usage
 

--- a/lib/mars_base_10/version.rb
+++ b/lib/mars_base_10/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MarsBase10
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/mars_base_10.gemspec
+++ b/mars_base_10.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/mars_base_10/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "mars-base-10"
+  spec.name          = "mars_base_10"
   spec.version       = MarsBase10::VERSION
   spec.license       = "MIT"
   spec.authors       = ["Daryl Richter"]
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7.0"
 
   spec.files =  Dir.glob("lib{.rb,/**/*}", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
-  spec.files += %w[mars-base-10.gemspec]    # include the gemspec itself because warbler breaks w/o it
+  spec.files += %w[mars_base_10.gemspec]    # include the gemspec itself because warbler breaks w/o it
 
   spec.bindir        = "bin"
   spec.executables   = %w[mb10]


### PR DESCRIPTION
## Why?

I wasn't thinking when I originally created and pushed this gem, but hyphens in gem names are supposed to be used for sub-modules.

## What Changed?

I have changed it to underscores which follows the conventions.

## Discussion / Considerations

This is going to strand people who have the older gem installed, but this is still new enough that I think it's acceptable. I preserved continuity with the version numbering so that if you search gems you may see both and be able to figure out what happened.

## QA / User Acceptance

None.